### PR TITLE
Fixed img links and alt texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Quick Settings Tweaker [<img src="images/quick-settings-tweaker.png" width="200px" align="right" alt="QuickSettings-Tweaker SkeletonUI">]("https://extensions.gnome.org/extension/5446/quick-settings-tweaker/")
+# Quick Settings Tweaker [<img src="images/quick-settings-tweaker.png" width="200px" align="right" alt="QuickSettings-Tweaker SkeletonUI">](https://extensions.gnome.org/extension/5446/quick-settings-tweaker/)
 
 <div align="center">
 
 ### Let's tweak Gnome 43 quick settings!
 
-[<img src="https://raw.githubusercontent.com/andyholmes/gnome-shell-extensions-badge/master/get-it-on-ego.svg?sanitize=true" alt="Get it on GNOME Extensions" height="100" align="middle">]("https://extensions.gnome.org/extension/5446/quick-settings-tweaker/")
+[<img src="https://raw.githubusercontent.com/andyholmes/gnome-shell-extensions-badge/master/get-it-on-ego.svg?sanitize=true" alt="Get it on GNOME Extensions" height="100" align="middle">](https://extensions.gnome.org/extension/5446/quick-settings-tweaker/)
 
 Quick Settings Tweaker is a Gnome 43+ extension which allows you to customize the new Quick Settings Panel to your liking!
 
@@ -16,6 +16,6 @@ Quick Settings Tweaker is a Gnome 43+ extension which allows you to customize th
 
 | With this extension, you can: | How it will appear |
 |:-------------------------------|:--------------------:|
-| <p>**Add a Volume Mixer**</p><p>To ajust the volume on a per-app basis</p> | <img src="images/screen_audio-mixer.png" width="250px" alt="QuickSettings-Tweaker SkeletonUI"> |
-| <p>**Add Media Controls**</p><p>To control your music directly from the Quick Settings Panel, instead of the Notification Center</p> | <img src="images/screen_media-controls.png" width="250px" alt="QuickSettings-Tweaker SkeletonUI"> |
-| <p>**Append a Notifications Panel** at the end of the QS Panel</p><p>Congrats! Now you really have a fully featured menu at the top right corner of your screen!</p> | <img src="images/screen_notifications.png" width="250px" alt="QuickSettings-Tweaker SkeletonUI"> |
+| <p>**Add a Volume Mixer**</p><p>To ajust the volume on a per-app basis</p> | <img src="images/screen_audio-mixer.png" width="250px" alt="Volume Mixer screenshot"> |
+| <p>**Add Media Controls**</p><p>To control your music directly from the Quick Settings Panel, instead of the Notification Center</p> | <img src="images/screen_media-controls.png" width="250px" alt="Media Controls screenshot"> |
+| <p>**Append a Notifications Panel** at the end of the QS Panel</p><p>Congrats! Now you really have a fully featured menu at the top right corner of your screen!</p> | <img src="images/screen_notifications.png" width="250px" alt="Notifications Center screenshot"> |


### PR DESCRIPTION
- Fixed the Gnome extensions button not pointing to the expected webpage
- Fixed alt texts of screenshots, which have all the same wrong description!