### PR TITLE
Add placeholder for no notifications

### DIFF
--- a/notifications.js
+++ b/notifications.js
@@ -48,14 +48,9 @@ var Notifications = GObject.registerClass(
 
             // no notifications text
             let noNotiBox = new St.BoxLayout({x_align: Clutter.ActorAlign.CENTER})
-            let noNotiLabel = new St.Label({
-                text: _("No Notifications"),
-                y_align: Clutter.ActorAlign.CENTER,
-                
-            })
             noNotiBox.style_class = "qwreey-notifications-no-notifications-box"
-            noNotiLabel.style_class = "qwreey-notifications-no-notifications"
-            noNotiBox.add_child(noNotiLabel)
+            const noNotiPlaceholder = new NoNotifPlaceholder();
+            noNotiBox.add_child(noNotiPlaceholder)
             noNotiBox.hide()
             this.add_child(noNotiBox)
 
@@ -99,3 +94,24 @@ var Notifications = GObject.registerClass(
         }
     }
 )
+
+const NoNotifPlaceholder = GObject.registerClass(
+class NoNotifPlaceholder extends St.BoxLayout {
+    _init() {
+        super._init({
+            style_class: 'qwreey-notifications-no-notifications-placeholder',
+            vertical: true,
+            opacity: 60
+        });
+
+        this._icon = new St.Icon({
+            icon_name: 'no-notifications-symbolic'
+        });
+        this.add_child(this._icon);
+
+        this._label = new St.Label({
+            text: _('No Notifications')
+        });
+        this.add_child(this._label);
+    }
+});

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -28,11 +28,9 @@
     padding: 0px !important;
     margin: 4px 0px 0px 0px !important;
 }
-.qwreey-notifications-no-notifications {
-    /* no notifications text */
-    font-size: 1em;
-    margin: 22px;
-    width: 100%;
+.qwreey-notifications-no-notifications-placeholder {
+    font-weight: bold;
+    margin: 24px;
 }
 .qwreey-notifications.qwreey-notifications-integrated .qwreey-notifications-no-notifications {
     margin: 16px !important;


### PR DESCRIPTION
I've just replaced the plain text with a icon+text. I don't know how you like the styling. So I just went with a 'GNOME'-ish look but ofc feel free to edit it. Here is how it currently looks

![scr](https://user-images.githubusercontent.com/53054301/199738302-c862949b-82ab-4372-ab63-a45e4d700cbe.png)

I think that the DND switch and the clear button look weird there. If you don't mind, I'll open a PR next to add DND as a Quick Toggle and move the clear button to the top as a 'header suffix' like I've done here

![image](https://user-images.githubusercontent.com/53054301/199739582-9443c3ed-b08f-4dd8-a6b3-d8b898bb52fc.png)
