### PR TITLE
Moves DND button to the quickSettingsMenu if DND toggle is enabled

### DIFF
--- a/features/dndQuickToggle.js
+++ b/features/dndQuickToggle.js
@@ -4,6 +4,8 @@ const Me = ExtensionUtils.getCurrentExtension()
 const featureReloader = Me.imports.libs.featureReloader
 const { QuickSettings } = Me.imports.libs.gnome
 const { Indicator } = Me.imports.libs.dndQuickToogleHandler
+const { DateMenu } = Me.imports.libs.gnome
+
 
 var dndQuickToggleFeature = class {
     load() {
@@ -19,12 +21,18 @@ var dndQuickToggleFeature = class {
         this.dndToggle = new Indicator()
         QuickSettings._indicators.add_child(this.dndToggle)
         QuickSettings._addItems(this.dndToggle.quickSettingsItems)
+        
+        //remove DND button from datemenu
+        this.datemenu_dnd = DateMenu.last_child.last_child
+        DateMenu.last_child.remove_actor(this.datemenu_dnd);
+        
     }
 
     unload() {
         // disable feature reloader
         featureReloader.disable(this)
-
+        //put back the button to the datemenu
+	DateMenu.last_child.add_child(this.datemenu_dnd);
         // Remove DND Quick Toggle
         if (this.dndToggle) {
             const dndQSItems = this.dndToggle.quickSettingsItems[0]

--- a/features/dndQuickToggle.js
+++ b/features/dndQuickToggle.js
@@ -5,6 +5,7 @@ const featureReloader = Me.imports.libs.featureReloader
 const { QuickSettings } = Me.imports.libs.gnome
 const { Indicator } = Me.imports.libs.dndQuickToogleHandler
 const { DateMenu } = Me.imports.libs.gnome
+const { Gio, GObject } = imports.gi;
 
 
 var dndQuickToggleFeature = class {
@@ -24,7 +25,8 @@ var dndQuickToggleFeature = class {
         
         //remove DND button from datemenu
         this.datemenu_dnd = DateMenu.last_child.last_child
-        DateMenu.last_child.remove_actor(this.datemenu_dnd);
+        this.datemenu_dnd.hide()
+        this.datemenu_dnd_connection = this.datemenu_dnd.connect("show", () => { this.datemenu_dnd.hide() })
         
     }
 
@@ -32,7 +34,14 @@ var dndQuickToggleFeature = class {
         // disable feature reloader
         featureReloader.disable(this)
         //put back the button to the datemenu
-	DateMenu.last_child.add_child(this.datemenu_dnd);
+	this.datemenu_dnd.disconnect(this.datemenu_dnd_connection)
+	this.datemenu_dnd_connection = null;
+	const _settings = new Gio.Settings({
+            schema_id: 'org.gnome.desktop.notifications',
+        });
+	if (!_settings.get_boolean('show-banners')){
+		this.datemenu_dnd.show();
+	}
         // Remove DND Quick Toggle
         if (this.dndToggle) {
             const dndQSItems = this.dndToggle.quickSettingsItems[0]

--- a/libs/dndQuickToogleHandler.js
+++ b/libs/dndQuickToogleHandler.js
@@ -1,5 +1,6 @@
 const { Gio, GObject } = imports.gi;
 const { QuickToggle, SystemIndicator } = imports.ui.quickSettings;
+const { St } = imports.gi
 
 const DndQuickToogle = GObject.registerClass(
 class DndQuickToogle extends QuickToggle {
@@ -41,6 +42,31 @@ class Indicator extends SystemIndicator {
     _init() {
         super._init();
 
+	this._indicator = this._addIndicator();
+
+	this._indicator.icon_name = 'notifications-disabled-symbolic'
         this.quickSettingsItems.push(new DndQuickToogle());
+
+        this._settings = new Gio.Settings({
+            schema_id: 'org.gnome.desktop.notifications',
+        });
+
+        this._changedId = this._settings.connect('changed::show-banners',
+            () => this._sync());
+        
+        this._sync();
     }
+    
+        _sync() {
+        const checked = !this._settings.get_boolean('show-banners');
+        if (checked){
+        	this._indicator.visible = true;
+        }
+        else{
+        this._indicator.visible = false;
+        }
+        
+    }
+    
+
 });


### PR DESCRIPTION
When the DND button is in the quickSettings Menu it makes no sense that the indicator is still in the datemenu. That fixes that