### PR TITLE
Update metadata.json for GNOME 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "name": "Quick Settings Tweaker",
   "url": "https://github.com/qwreey75/quick-settings-tweaks",
   "shell-version": [
-    "43"
+    "43",
+    "44"
   ],
   "uuid": "quick-settings-tweaks@qwreey",
   "settings-schema": "org.gnome.shell.extensions.quick-settings-tweaks",


### PR DESCRIPTION
Gnome 44 was released on March 22, 2023. This PR add 44 to the manifest
