### PR TITLE
Fix errors & compatibilities issues

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -28,6 +28,7 @@ class Extension {
             feature.unload()
             feature.settings = null
         }
+        this.features = null;
     
         logger("Diabled")
     }

--- a/features/dndQuickToggle.js
+++ b/features/dndQuickToggle.js
@@ -15,6 +15,7 @@ var dndQuickToggleFeature = class {
       "add-dnd-quick-toggle-enabled",
     ]);
 
+    this.datemenu_dnd = null;
     // check is feature enabled
     if (!this.settings.get_boolean("add-dnd-quick-toggle-enabled")) return;
 
@@ -51,6 +52,9 @@ var dndQuickToggleFeature = class {
   unload() {
     // disable feature reloader
     featureReloader.disable(this);
+
+    if (this.datemenu_dnd == null) return;
+
     //put back the button to the datemenu
     this.datemenu_dnd.disconnect(this.datemenu_dnd_connection);
     this.datemenu_dnd_connection = null;

--- a/features/inputOutput.js
+++ b/features/inputOutput.js
@@ -17,6 +17,7 @@ var inputOutputFeature = class {
             "input-always-show"
         ])
 
+        this._inputStreamSlider = this._getInputStreamSlider()
         this._setupOutputChangedListener()
         this._setupInputChangedListener()
         this._setupInputVisibilityObserver()
@@ -34,9 +35,10 @@ var inputOutputFeature = class {
         Volume.getMixerControl().disconnect(this._inputListener)
         this._inputListener = null
 
-        this._getInputStreamSlider().disconnect(this._inputVisibilityListener)
+        this._inputStreamSlider.disconnect(this._inputVisibilityListener)
         this._inputVisibilityListener = null
-        this._getInputStreamSlider().visible = this._getInputStreamSlider()._shouldBeVisible()
+        this._inputStreamSlider.visible = this._inputStreamSlider._shouldBeVisible()
+        this._inputStreamSlider = null
     }
 
     // =========================================== Ouput ===========================================
@@ -78,7 +80,7 @@ var inputOutputFeature = class {
         addChildWithIndex(QuickSettingsGrid, this.inputLabel, this._getInputStreamSliderIndex() - 1)
         this._spanTwoColumns(this.inputLabel)
         this._setInputLabelVisibility()
-        this.inputLabel.text = this._findActiveDevice(this._getInputStreamSlider())
+        this.inputLabel.text = this._findActiveDevice(this._inputStreamSlider)
     }
 
     _onInputDeviceChanged(deviceId) {
@@ -96,7 +98,7 @@ var inputOutputFeature = class {
 
     // =========================================== Input Visbility ===========================================
     _setupInputVisibilityObserver() {
-        this._inputVisibilityListener = this._getInputStreamSlider().connect("notify::visible", () => this._onInputStreamSliderSynced())
+        this._inputVisibilityListener = this._inputStreamSlider.connect("notify::visible", () => this._onInputStreamSliderSynced())
         this._onInputStreamSliderSynced()
     }
 
@@ -106,11 +108,11 @@ var inputOutputFeature = class {
     }
 
     _setInputStreamSliderVisibility() {
-        this._getInputStreamSlider().visible = this._getInputStreamSlider()._shouldBeVisible() || this.settings.get_boolean("input-always-show")
+        this._inputStreamSlider.visible = this._inputStreamSlider._shouldBeVisible() || this.settings.get_boolean("input-always-show")
     }
 
     _setInputLabelVisibility() {
-        this.inputLabel.visible = this._getInputStreamSlider().visible && this.settings.get_boolean("input-show-selected")
+        this.inputLabel.visible = this._inputStreamSlider.visible && this.settings.get_boolean("input-show-selected")
     }
 
 

--- a/features/inputOutput.js
+++ b/features/inputOutput.js
@@ -18,27 +18,35 @@ var inputOutputFeature = class {
         ])
 
         this._inputStreamSlider = this._getInputStreamSlider()
-        this._setupOutputChangedListener()
-        this._setupInputChangedListener()
-        this._setupInputVisibilityObserver()
+        if (this._inputStreamSlider) {
+            this._setupInputChangedListener()
+            this._setupInputVisibilityObserver()
+        }
+        this._outputStreamSlider = this._getOutputStreamSlider()
+        if (this._outputStreamSlider) {
+            this._setupOutputChangedListener()
+        }
     }
 
     unload() {
         // disable feature reloader
         featureReloader.disable(this)
 
-        this._detachOutputLabel()
-        Volume.getMixerControl().disconnect(this._outputListener)
-        this._outputListener = null
+        if (this._inputStreamSlider) {
+            this._detachInputLabel()
+            Volume.getMixerControl().disconnect(this._inputListener)
+            this._inputListener = null
 
-        this._detachInputLabel()
-        Volume.getMixerControl().disconnect(this._inputListener)
-        this._inputListener = null
-
-        this._inputStreamSlider.disconnect(this._inputVisibilityListener)
-        this._inputVisibilityListener = null
-        this._inputStreamSlider.visible = this._inputStreamSlider._shouldBeVisible()
-        this._inputStreamSlider = null
+            this._inputStreamSlider.disconnect(this._inputVisibilityListener)
+            this._inputVisibilityListener = null
+            this._inputStreamSlider.visible = this._inputStreamSlider._shouldBeVisible()
+            this._inputStreamSlider = null
+        }
+        if (this._outputStreamSlider) {
+            this._detachOutputLabel()
+            Volume.getMixerControl().disconnect(this._outputListener)
+            this._outputListener = null
+        }
     }
 
     // =========================================== Ouput ===========================================
@@ -58,7 +66,7 @@ var inputOutputFeature = class {
         addChildWithIndex(QuickSettingsGrid, this.outputLabel, this._getOutputStreamSliderIndex() - 1);
         this._spanTwoColumns(this.outputLabel)
         this.outputLabel.visible = this.settings.get_boolean("output-show-selected")
-        this.outputLabel.text = this._findActiveDevice(this._getOutputStreamSlider())
+        this.outputLabel.text = this._findActiveDevice(this._outputStreamSlider)
     }
 
     _detachOutputLabel() {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -102,10 +102,6 @@
         }
         .QSTWEAKS-notifications-separated {
             padding: 16px 4px 16px 16px;
-            margin: 6px 12px 6px 12px;
-        }
-        .QSTWEAKS-quick-settings-separated {
-            margin: 6px 12px 6px 12px;
         }
         .QSTWEAKS-notifications-separated .QSTWEAKS-notifications-no-notifications-placeholder {
             margin: 16px 0px;


### PR DESCRIPTION
This pull request:
  - fix a crash when disabling the extension
  - prevent the extension from crashing if volume sliders are not present (which prevent errors when [Quick Settings Audio Panel](https://github.com/Rayzeq/quick-settings-audio-panel) move them)
  - make so the extension don't resize the panels when notifications are in their own panel